### PR TITLE
Pull Terraform from Alpine Packages and upgrade Terragrunt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 FROM alpine
 
 #Install Deps
-RUN apk update && \
-    apk add jq unzip wget
-
-#Install Terraform
-RUN wget https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_linux_amd64.zip
-RUN unzip terraform_1.2.0_linux_amd64.zip -d /usr/local/bin/
-RUN chmod +x /usr/local/bin/terraform
+RUN apk add --no-cache jq terraform unzip wget
 
 #Install Terragrunt
 ADD https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 /usr/local/bin/terragrunt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ FROM alpine
 RUN apk add --no-cache jq terraform unzip wget
 
 #Install Terragrunt
-ADD https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 /usr/local/bin/terragrunt
+ADD https://github.com/gruntwork-io/terragrunt/releases/download/v0.43.2/terragrunt_linux_amd64 /usr/local/bin/terragrunt
 RUN chmod +x /usr/local/bin/terragrunt


### PR DESCRIPTION
Updated the apk call to not bloat the image with it's catalogues.
Since v3.17 there is a Terraform package available.
Upstream `alpine:edge` even has terragrunt, now. 

Please see:
- https://www.docker.com/blog/how-to-use-the-alpine-docker-official-image/
- https://pkgs.alpinelinux.org/packages?name=terra*&branch=v3.17&repo=&arch=&maintainer=
- https://pkgs.alpinelinux.org/packages?name=terra*&branch=edge&repo=&arch=&maintainer=
- https://github.com/gruntwork-io/terragrunt/releases/tag/v0.43.2

[build.log](https://github.com/galdorork/terragrunt-proxmox-provisioner/files/10714501/build.log)
